### PR TITLE
refactor: 💡 Replaced the deprecated SafeAreaView from react-nat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "5.4.7",
       "license": "MIT",
       "dependencies": {
-        "react-native-gesture-handler": "~2.13.1"
+        "react-native-gesture-handler": "~2.13.1",
+        "react-native-safe-area-context": "^5.6.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.25",
@@ -5510,20 +5511,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -8551,6 +8538,16 @@
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
+      "integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "react-native-gesture-handler": "~2.13.1"
+    "react-native-gesture-handler": "~2.13.1",
+    "react-native-safe-area-context": "^5.6.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.25",

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -16,13 +16,14 @@ import {
   Image,
   Modal,
   Platform,
-  SafeAreaView,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
+
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { FlatList, ScrollView } from 'react-native-gesture-handler';
 import {


### PR DESCRIPTION
Replaced the deprecated SafeAreaView from react-native with the one from react-native-safe-area-context to ensure compatibility with newer versions and proper safe area handling.

Recreating [pr 783](https://github.com/hossein-zare/react-native-dropdown-picker/pull/783)

https://github.com/hossein-zare/react-native-dropdown-picker/pull/783